### PR TITLE
feat: prompt user to create a personal access token beforehand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9601,6 +9601,21 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "open": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.0.0.tgz",
+      "integrity": "sha512-K6EKzYqnwQzk+/dzJAQSBORub3xlBTxMz+ntpZpH/LyCa1o6KjXhuN+2npAaI9jaSmU3R1Q8NWf4KUWcyytGsQ==",
+      "requires": {
+        "is-wsl": "^2.1.0"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+          "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog=="
+        }
+      }
+    },
     "opn": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "execa": "^1.0.0",
     "inquirer": "^6.2.0",
     "node-banner": "^1.3.2",
-    "python-shell": "^1.0.7"
+    "python-shell": "^1.0.7",
+    "open": "^7.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -47,7 +47,7 @@ const showInstructions = kickStart => {
 };
 
 const promptAccessTokenCreation = async () => {
-  const instructionUrl =
+  const instructionsUrl =
     'https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line';
   console.log();
   console.log(
@@ -60,12 +60,11 @@ const promptAccessTokenCreation = async () => {
       name: 'openInBrowser',
       type: 'confirm',
       message: 'Open browser to read instructions?',
-      default: true,
     },
   ]);
-  if (openInBrowser === true) {
-    // open link in default browser
-    await open(instructionUrl);
+  if (openInBrowser) {
+    // open link in the default browser
+    await open(instructionsUrl);
   }
 };
 

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -5,6 +5,7 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const inquirer = require('inquirer');
 const showBanner = require('node-banner');
+const open = require('open');
 
 // GitHub workflow helper methods.
 const {
@@ -43,6 +44,29 @@ const showInstructions = kickStart => {
 
   key = kickStart ? key : '<key>';
   console.log(chalk.cyan.bold(` 2. teachcode fetchtask ${key}`));
+};
+
+const promptAccessTokenCreation = async () => {
+  const instructionUrl =
+    'https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line';
+  console.log();
+  console.log(
+    chalk.greenBright(
+      'You are required to have a personal access token for consuming the GitHub API.\nIf you do not have one, please follow these instructions.\n',
+    ),
+  );
+  const { openInBrowser } = await inquirer.prompt([
+    {
+      name: 'openInBrowser',
+      type: 'confirm',
+      message: ' Open browser to read instructions? ',
+      default: true,
+    },
+  ]);
+  if (openInBrowser === true) {
+    // open link in default browser
+    await open(instructionUrl);
+  }
 };
 
 /**
@@ -122,6 +146,7 @@ const initTasks = async () => {
   let kickStart;
 
   if (shouldCreateRepository) {
+    await promptAccessTokenCreation();
     await createRepository();
     kickStart = true;
 


### PR DESCRIPTION
## Description

This is a WIP PR.
- [x] The prompt is positioned to come before the repo needs to be created for a new user. (For existing users of teachcode, it is not needed)
- [x] Open the GitHub help page for access token creation in the browser.
- [ ] Documentation

Fixes # 23

## Type of change

- [x] New feature

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules