### PR TITLE
fix: key is optional now issue 54

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -31,7 +31,7 @@ program
   .action(submitTask);
 
 program
-  .command('fetchtask <key>')
+  .command('fetchtask [key]')
   .description('Fetches any task as per the key supplied')
   .action(fetchTask);
 

--- a/src/commands/tasks.js
+++ b/src/commands/tasks.js
@@ -47,6 +47,10 @@ const fetchTask = async key => {
     keys,
   } = userConfig;
 
+  if (!key) {
+    key = keys.slice(-1).pop();
+  }
+
   if (learningTrack === 'Python') {
     fileName = `task${taskCount + 1}.py`;
     exercises = require('../workspace/python/tasks');


### PR DESCRIPTION
## Description
Issue 54 .
Fixes # (issue)

- [ In fetchtask command key is option is made as optional. ] New feature (non-breaking change which adds functionality)
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
