### PR TITLE
fix: regression with create repository implemenation

### DIFF
--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -92,7 +92,7 @@ const createRepository = async () => {
     type: 'input',
     validate,
   });
-  
+
   const API_URL = `https://api.github.com/user/repos`;
   axios.defaults.headers.common['Authorization'] = `token ${userToken}`;
   // Create a new repository.

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -92,8 +92,9 @@ const createRepository = async () => {
     type: 'input',
     validate,
   });
-  const API_URL = `https://api.github.com/user/repos?access_token=${userToken}`;
-
+  
+  const API_URL = `https://api.github.com/user/repos`;
+  axios.defaults.headers.common['Authorization'] = `token ${userToken}`;
   // Create a new repository.
   try {
     await axios.post(API_URL, { name: 'teachcode-solutions' });


### PR DESCRIPTION


Bug fix for #78 

Solution for the api authentication through query parameters deprecated warning.

**Motivation behind the fix
The command ```teachcode fetchtask <key>``` requires  personal access token and it could not be accessed and reason is described here. https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

link to issue https://github.com/madlabsinc/teachcode/issues/78
